### PR TITLE
Bugfix for issue 54

### DIFF
--- a/bifromq-session-dict/bifromq-session-dict-server/src/main/java/com/baidu/bifromq/sessiondict/server/SessionRegister.java
+++ b/bifromq-session-dict/bifromq-session-dict-server/src/main/java/com/baidu/bifromq/sessiondict/server/SessionRegister.java
@@ -88,7 +88,9 @@ class SessionRegister extends AckStream<Session, Quit> implements ISessionRegist
     public boolean kick(String tenantId, ClientKey clientKey, ClientInfo kicker) {
         AtomicReference<ClientInfo> found = new AtomicReference<>();
         registeredSession.computeIfPresent(tenantId, (k, v) -> {
-            found.set(v.remove(clientKey));
+            if (v.containsKey(clientKey) && !v.get(clientKey).equals(kicker)) {
+                found.set(v.remove(clientKey));
+            }
             if (v.isEmpty()) {
                 v = null;
             }

--- a/bifromq-session-dict/bifromq-session-dict-server/src/test/java/com/baidu/bifromq/sessiondict/server/SessionRegisterTest.java
+++ b/bifromq-session-dict/bifromq-session-dict-server/src/test/java/com/baidu/bifromq/sessiondict/server/SessionRegisterTest.java
@@ -205,6 +205,22 @@ public class SessionRegisterTest {
         });
     }
 
+    @Test
+    public void ignoreSelfKick() {
+        test(() -> {
+            SessionRegister register = new SessionRegister(listener, responseObserver);
+            register.onNext(Session.newBuilder()
+                .setReqId(System.nanoTime())
+                .setOwner(owner)
+                .setKeep(true)
+                .build());
+            register.kick(tenantId,
+                new ISessionRegister.ClientKey(userId, owner.getMetadataOrDefault(MQTT_CLIENT_ID_KEY, clientId)),
+                owner);
+            verify(responseObserver, times(0)).onNext(any());
+        });
+    }
+
 
     private void test(Runnable runnable) {
         Context ctx = Context.ROOT


### PR DESCRIPTION
Fix that shutting down a BifroMQ node may result in the possibility of MQTT connections on other nodes being kicked off.
